### PR TITLE
feat(backend/ops): basic metrics, timings, and optional API key guard

### DIFF
--- a/museagent/backend/config/settings.py
+++ b/museagent/backend/config/settings.py
@@ -1,4 +1,5 @@
 from pydantic_settings import BaseSettings
+from typing import Optional
 
 
 class Settings(BaseSettings):
@@ -9,6 +10,9 @@ class Settings(BaseSettings):
     FAISS_METRIC: str = "cosine"
     ENABLE_GENERATION: bool = False
     ENABLE_SEGMENTS: bool = False
+    # Security
+    API_KEY: Optional[str] = None
+    REQUIRE_API_KEY: bool = False
 
     class Config:
         env_file = ".env"


### PR DESCRIPTION
- /metrics returns request counts and latency percentiles (p50/p90/p99).
- Measure /analyze latency; count analyzed tracks.
- Optional API key enforcement via settings (header x-api-key or query api_key).
- Keeps health/readiness and static mounts open for demo.