### PR TITLE
feat(ui): remove bottom mini-player; add per-card transports; richer …

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -21,7 +21,6 @@
     <div id="splash" role="status" aria-live="polite">
       <div class="splash-content">
         <img id="splash-logo" class="splash-logo" src="/assets/ma-logo.png" alt="MuseAgent logo" />
-        <div class="splash-title">MuseAgent</div>
         <div class="splash-subtitle muted">Music Intelligence — analyze • tag • recommend • report</div>
       </div>
     </div>
@@ -130,7 +129,7 @@
       <div id="panel-explore" class="panel" role="tabpanel" aria-labelledby="tab-explore">
         <section class="card">
           <div style="display:flex;align-items:center;justify-content:space-between;gap:1rem">
-            <h2 style="margin:0">Library</h2>
+            <h2 style="margin:0"></h2>
             <div class="row">
               <select id="filter-key"><option value="">All Keys</option><option>C</option><option>G</option><option>D</option><option>A</option><option>E</option><option>F</option><option>Am</option><option>Em</option><option>Dm</option><option>Gm</option></select>
               <select id="filter-mood"><option value="">All Moods</option><option>chill</option><option>energetic</option><option>happy</option><option>sad</option><option>dark</option></select>
@@ -227,14 +226,7 @@
       </div>
     </div>
 
-    <!-- Mini player -->
-    <div id="player" class="player" aria-label="Mini player" role="region">
-      <button id="player-prev" title="Previous">⏮</button>
-      <button id="player-play" title="Play/Pause">▶</button>
-      <button id="player-next" title="Next">⏭</button>
-      <div class="player-title" id="player-title">—</div>
-      <div class="player-progress" aria-label="Progress"><span id="player-bar"></span></div>
-    </div>
+    
 
     <script src="./app.js"></script>
     <script>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -222,11 +222,7 @@ button:hover { box-shadow: 0 0 18px rgba(242,212,96,0.25); }
 .overlay.show { display:flex; }
 .overlay-inner { width:min(720px,92vw); background: var(--ma-surface); border:1px solid rgba(255,255,255,0.12); border-radius:14px; padding:1rem; }
 
-/* Mini player */
-.player { position: fixed; left: 0; right: 0; bottom: 0; display:flex; align-items:center; gap:.6rem; padding:.5rem .75rem; background: rgba(0,0,0,0.35); backdrop-filter: blur(6px); border-top:1px solid rgba(255,255,255,0.08); z-index: 1300; }
-.player-title { flex:1; color: var(--ma-text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.player-progress { flex:2; height: 6px; background: rgba(255,255,255,0.08); border-radius: 999px; overflow: hidden; }
-.player-progress > span { display:block; height:100%; background: var(--ma-fg); width: 0%; }
+/* Removed mini player */
 
 /* Similarity map */
 #map-canvas { width: 100%; height: auto; background: rgba(255,255,255,0.03); border-radius: 12px; }

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'museagent-cache-v7';
+const CACHE_NAME = 'museagent-cache-v9';
 const ASSETS = [
   './index.html',
   './styles.css',


### PR DESCRIPTION
…Insights visuals

- Remove global player bar; reduce clutter and avoid overlap
- Explore: tiny play/pause/prev/next on each card (audio beeps demo)
- Insights: populate list from library; add tiny transports per item
- Insights: mood map now multi-point with highlighted selection
- Remove 'Library' heading; cache bump to v9